### PR TITLE
Add version test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,16 @@ Crie plugins JavaScript em `/etc/fazai/tools/` implementando:
 
 Crie módulos C em `/etc/fazai/mods/` implementando as funções definidas em `fazai_mod.h`.
 
+## Testes
+
+Execute a suíte de testes com:
+
+```bash
+npm test
+```
+
+O script `tests/version.test.sh` valida se `bin/fazai --version` corresponde à versão em `package.json`.
+
 ## Desinstalação
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "install-wsl": "wsl --root bash install.sh",
     "test-wsl": "wsl --root bash tests/fazai.tests.ps1",
     "test-system-wsl": "wsl --root bash tests/system-tools.tests.ps1",
-    "test": "npm run test-wsl && npm run test-system-wsl",
+    "test": "bash tests/version.test.sh && npm run test-wsl && npm run test-system-wsl",
     "tui": "bash opt/fazai/tools/fazai-tui.sh",
     "config-tui": "bash opt/fazai/tools/fazai-config-tui.sh",
     "web": "bash opt/fazai/tools/fazai_web.sh"

--- a/tests/version.test.sh
+++ b/tests/version.test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+EXPECTED="$(node -p "require('./package.json').version")"
+OUTPUT="$(node ./bin/fazai --version 2>/dev/null | tr -d '\r\n')"
+if [ "$OUTPUT" = "FazAI v$EXPECTED" ]; then
+  echo "Version test passed: $OUTPUT"
+  exit 0
+else
+  echo "Version mismatch: expected 'FazAI v$EXPECTED' but got '$OUTPUT'"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add `tests/version.test.sh`
- run the version test before existing scripts via `npm test`
- document how to run tests

## Testing
- `bash tests/version.test.sh` *(fails: Version mismatch)*
- `npm test` *(fails: Version mismatch and network access)*

------
https://chatgpt.com/codex/tasks/task_e_685bbc0d86e4832e8c2ecc2a91ce2ee5