### PR TITLE
Add reinstall script and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Para ambientes com restrições de rede ou onde a instalação normal falha:
 wget https://github.com/RLuf/FazAI/releases/latest/download/fazai-portable.tar.gz
 tar -xzf fazai-portable.tar.gz
 cd fazai-portable-*
-sudo ./install-portable.sh
+sudo ./install.sh
 ```
 
 ### Instalação via Docker
@@ -149,6 +149,9 @@ sudo ./uninstall.sh
 ```
 
 ## Reinstalação
+
+Para reinstalar completamente o FazAI utilize o script `reinstall.sh`. Ele
+executa `uninstall.sh` e em seguida `install.sh` de forma automática:
 
 ```bash
 sudo ./reinstall.sh

--- a/reinstall.sh
+++ b/reinstall.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# FazAI - Script de Reinstalação
+# Este script remove e instala novamente o FazAI
+
+set -e
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+
+"$DIR/uninstall.sh"
+"$DIR/install.sh"


### PR DESCRIPTION
## Summary
- add a `reinstall.sh` helper that runs uninstall then install
- document how to run the portable package using `install.sh`
- clarify reinstall procedure in README

## Testing
- `npm test` *(fails: `wsl` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bbdbad304832eb0c9ff8708b00494