### PR TITLE
Update version strings to 1.3.7

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,7 @@ cole aqui os logs (use o comando 'fazai logs 20' para obter os últimos 20 logs)
 **Ambiente (por favor, complete as seguintes informações):**
  - Sistema Operacional: [ex. Ubuntu 22.04]
  - Versão do Node.js: [ex. 16.14.0]
- - Versão do FazAI: [ex. 1.3.1]
+ - Versão do FazAI: [ex. 1.3.7]
 
 **Informações adicionais**
 Adicione qualquer outra informação sobre o problema aqui.

--- a/bin/fazai
+++ b/bin/fazai
@@ -339,7 +339,7 @@ ${colors.bright}Exemplos:${colors.reset}
   }
   
   if (args[0] === 'versao' || args[0] === 'version' || args[0] === '--version' || args[0] === '-v') {
-    console.log(`FazAI v1.3.1`);
+    console.log(`FazAI v1.3.7`);
     process.exit(0);
   }
   

--- a/opt/fazai/lib/main.js
+++ b/opt/fazai/lib/main.js
@@ -490,7 +490,7 @@ app.get('/status', (req, res) => {
     success: true, 
     status: 'online',
     timestamp: new Date().toISOString(),
-    version: '1.3.1'
+    version: '1.3.7'
   });
 });
 


### PR DESCRIPTION
## Summary
- bump CLI version output to 1.3.7
- report version 1.3.7 from `/status` endpoint
- update bug report template example version

## Testing
- `npm test` *(fails: `wsl` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bbf47665c832e9e6609254fa98867