### PR TITLE
Fix fazai-tui.sh shebang

### DIFF
--- a/opt/fazai/tools/fazai-tui.sh
+++ b/opt/fazai/tools/fazai-tui.sh
@@ -1,5 +1,3 @@
-
-Vou criar uma versão completa do frontend em ncurses TUI com o nome `fazai-tui` que será um dashboard completo para gerenciamento do FazAI, similar ao frontend web mas em interface de texto. Depois ajustarei todos os arquivos necessários.
 #!/bin/bash
 # FazAI - Interface TUI Dashboard Completa
 # Caminho: /opt/fazai/tools/fazai-tui.sh


### PR DESCRIPTION
## Summary
- remove stray Portuguese line before `#!/bin/bash`
- mark `fazai-tui.sh` as executable

## Testing
- `bash -n opt/fazai/tools/fazai-tui.sh`

------
https://chatgpt.com/codex/tasks/task_e_685bc24277f8832e909c6e6508465ce6