### PR TITLE
Update default port to 3210

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 # Renomeie este arquivo para .env e ajuste as configurações conforme necessário
 
 # Configurações do Servidor
-PORT=3120                      # Porta em que o daemon será executado
+PORT=3210                      # Porta em que o daemon será executado
 
 # Configurações de API de Provedores de IA
 OPENAI_API_KEY=sua_chave_openai_aqui    # Chave de API da OpenAI

--- a/LOGS_MANAGEMENT.md
+++ b/LOGS_MANAGEMENT.md
@@ -49,25 +49,25 @@ O daemon FazAI agora inclui endpoints específicos para gerenciamento de logs:
 ##### GET /logs
 Retorna as últimas entradas de log
 ```bash
-curl "http://localhost:3120/logs?lines=10"
+curl "http://localhost:3210/logs?lines=10"
 ```
 
 ##### POST /logs/clear
 Limpa o arquivo de log (cria backup)
 ```bash
-curl -X POST "http://localhost:3120/logs/clear"
+curl -X POST "http://localhost:3210/logs/clear"
 ```
 
 ##### GET /logs/download
 Faz download do arquivo de log
 ```bash
-curl "http://localhost:3120/logs/download" -o fazai-logs.log
+curl "http://localhost:3210/logs/download" -o fazai-logs.log
 ```
 
 ##### GET /status
 Verifica o status do daemon
 ```bash
-curl "http://localhost:3120/status"
+curl "http://localhost:3210/status"
 ```
 
 ## Arquivos Criados/Modificados
@@ -124,7 +124,7 @@ Quando os logs são limpos, um backup é criado automaticamente com timestamp:
 fazai limpar-logs
 
 # Via API
-curl -X POST "http://localhost:3120/logs/clear"
+curl -X POST "http://localhost:3210/logs/clear"
 ```
 
 ### Cenário 2: Monitoramento via Interface Web
@@ -139,13 +139,13 @@ curl -X POST "http://localhost:3120/logs/clear"
 # Script de manutenção
 
 echo "Fazendo backup dos logs..."
-curl "http://localhost:3120/logs/download" -o "backup-$(date +%Y%m%d).log"
+curl "http://localhost:3210/logs/download" -o "backup-$(date +%Y%m%d).log"
 
 echo "Limpando logs antigos..."
-curl -X POST "http://localhost:3120/logs/clear"
+curl -X POST "http://localhost:3210/logs/clear"
 
 echo "Verificando status do daemon..."
-curl "http://localhost:3120/status"
+curl "http://localhost:3210/status"
 ```
 
 ## Troubleshooting

--- a/bin/fazai
+++ b/bin/fazai
@@ -52,7 +52,7 @@ if (!fs.existsSync(mainJsPath)) {
 }
 
 // Configuração do cliente
-const API_URL = process.env.FAZAI_API_URL || 'http://localhost:3120';
+const API_URL = process.env.FAZAI_API_URL || 'http://localhost:3210';
 const LOG_FILE = '/var/log/fazai/fazai.log';
 
 // Cores para saída no terminal

--- a/install.sh
+++ b/install.sh
@@ -522,7 +522,7 @@ console.log('FazAI v1.3.7 - Iniciando...');
 
 // Configuração básica
 const config = {
-  port: process.env.FAZAI_PORT || 3120,
+  port: process.env.FAZAI_PORT || 3210,
   logLevel: process.env.FAZAI_LOG_LEVEL || 'info'
 };
 
@@ -752,7 +752,7 @@ echo "
         </div>
     </div>
     <script>
-        const API_URL = 'http://localhost:3120';
+        const API_URL = 'http://localhost:3210';
         
         async function viewLogs() {
             try {

--- a/opt/fazai/lib/main.js
+++ b/opt/fazai/lib/main.js
@@ -43,7 +43,7 @@ const logger = winston.createLogger({
 
 // Configuração do servidor Express
 const app = express();
-const PORT = process.env.PORT || 3120;
+const PORT = process.env.PORT || 3210;
 
 // Middleware para processar JSON
 app.use(express.json());

--- a/opt/fazai/tools/fazai-config.js
+++ b/opt/fazai/tools/fazai-config.js
@@ -118,7 +118,7 @@ function loadConfig() {
         system: {
           max_memory: '512M',
           threads: '4',
-          port: '3120',
+          port: '3210',
           host: 'localhost',
         }
       };

--- a/opt/fazai/tools/fazai-tui.sh
+++ b/opt/fazai/tools/fazai-tui.sh
@@ -8,7 +8,7 @@ Vou criar uma versão completa do frontend em ncurses TUI com o nome `fazai-tui`
 # Configurações
 CONFIG_FILE="/etc/fazai/fazai.conf"
 LOG_FILE="/var/log/fazai/fazai.log"
-API_URL="http://localhost:3120"
+API_URL="http://localhost:3210"
 DIALOG_TITLE="FazAI - Dashboard TUI"
 VERSION="1.3.7"
 
@@ -426,7 +426,7 @@ configure_api_keys() {
 
 # Função para configurar daemon
 configure_daemon() {
-    local port=$(grep '^daemon_port' "$CONFIG_FILE" 2>/dev/null | cut -d'=' -f2 | xargs || echo "3120")
+    local port=$(grep '^daemon_port' "$CONFIG_FILE" 2>/dev/null | cut -d'=' -f2 | xargs || echo "3210")
     local log_level=$(grep '^log_level' "$CONFIG_FILE" 2>/dev/null | cut -d'=' -f2 | xargs || echo "info")
     
     exec 3>&1

--- a/opt/fazai/tools/fazai_web_frontend.html
+++ b/opt/fazai/tools/fazai_web_frontend.html
@@ -361,7 +361,7 @@
                 <h3>🔧 Configuração</h3>
                 <div class="input-group">
                     <label for="apiUrl">URL da API:</label>
-                    <input type="text" id="apiUrl" value="http://localhost:3120">
+                    <input type="text" id="apiUrl" value="http://localhost:3210">
                 </div>
                 <div class="input-group">
                     <label for="refreshInterval">Intervalo de atualização (ms):</label>
@@ -376,7 +376,7 @@
     <script>
         // Configuração global
         let config = {
-            apiUrl: 'http://localhost:3120',
+            apiUrl: 'http://localhost:3210',
             refreshInterval: 5000
         };
 


### PR DESCRIPTION
## Summary
- switch default daemon port to 3210 in code and docs
- update install script and example config

## Testing
- `npm test` *(fails: `wsl` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc7f827a8832eae4e37472fb73224