### PR TITLE
Fix port documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 # Renomeie este arquivo para .env e ajuste as configurações conforme necessário
 
 # Configurações do Servidor
-PORT=3210                      # Porta em que o daemon será executado
+PORT=3120                      # Porta em que o daemon será executado
 
 # Configurações de API de Provedores de IA
 OPENAI_API_KEY=sua_chave_openai_aqui    # Chave de API da OpenAI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v1.3.8] - 14/06/2025
+
+### Changed
+- Porta padrão restaurada para **3120** com range reservado **3120-3125**.
+- Documentação e scripts atualizados para refletir a porta correta.
+
 ## [v1.3.7] - 13/06/2025
 
 ### Added
@@ -129,7 +135,7 @@
 - Logging detalhado de cada etapa da instalação
 - Unificação do fazai-config como subcomando do CLI principal
 - Suporte oficial a Docker com imagem pronta para uso
-- Definição da faixa de portas oficial do FazAI (3210-3215)
+- Definição da faixa de portas oficial do FazAI (3120-3125)
 
 ### Changed
 - Refatoração do install.sh para maior robustez e modularidade

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM debian:stable-slim
 
 # Definir variáveis de ambiente
-ENV FAZAI_PORT=3210 \
+ENV FAZAI_PORT=3120 \
     NODE_ENV=production
 
 # Instalar dependências do sistema
@@ -32,8 +32,8 @@ RUN npm install
 RUN chmod +x /opt/fazai/bin/fazai /opt/fazai/install.sh
 
 # Expor a porta oficial do FazAI
-# Range reservado: 3210-3215
-EXPOSE 3210
+# Range reservado: 3120-3125
+EXPOSE 3120
 
 # Volumes para persistência
 VOLUME ["/etc/fazai", "/var/log/fazai"]

--- a/LOGS_MANAGEMENT.md
+++ b/LOGS_MANAGEMENT.md
@@ -49,25 +49,25 @@ O daemon FazAI agora inclui endpoints específicos para gerenciamento de logs:
 ##### GET /logs
 Retorna as últimas entradas de log
 ```bash
-curl "http://localhost:3210/logs?lines=10"
+curl "http://localhost:3120/logs?lines=10"
 ```
 
 ##### POST /logs/clear
 Limpa o arquivo de log (cria backup)
 ```bash
-curl -X POST "http://localhost:3210/logs/clear"
+curl -X POST "http://localhost:3120/logs/clear"
 ```
 
 ##### GET /logs/download
 Faz download do arquivo de log
 ```bash
-curl "http://localhost:3210/logs/download" -o fazai-logs.log
+curl "http://localhost:3120/logs/download" -o fazai-logs.log
 ```
 
 ##### GET /status
 Verifica o status do daemon
 ```bash
-curl "http://localhost:3210/status"
+curl "http://localhost:3120/status"
 ```
 
 ## Arquivos Criados/Modificados
@@ -124,7 +124,7 @@ Quando os logs são limpos, um backup é criado automaticamente com timestamp:
 fazai limpar-logs
 
 # Via API
-curl -X POST "http://localhost:3210/logs/clear"
+curl -X POST "http://localhost:3120/logs/clear"
 ```
 
 ### Cenário 2: Monitoramento via Interface Web
@@ -139,13 +139,13 @@ curl -X POST "http://localhost:3210/logs/clear"
 # Script de manutenção
 
 echo "Fazendo backup dos logs..."
-curl "http://localhost:3210/logs/download" -o "backup-$(date +%Y%m%d).log"
+curl "http://localhost:3120/logs/download" -o "backup-$(date +%Y%m%d).log"
 
 echo "Limpando logs antigos..."
-curl -X POST "http://localhost:3210/logs/clear"
+curl -X POST "http://localhost:3120/logs/clear"
 
 echo "Verificando status do daemon..."
-curl "http://localhost:3210/status"
+curl "http://localhost:3120/status"
 ```
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -64,18 +64,18 @@ docker build -t fazai:latest .
 
 # Executar o container
 docker run -d --name fazai \
-  -p 3210:3210 \
+  -p 3120:3120 \
   -v /etc/fazai:/etc/fazai \
   -v /var/log/fazai:/var/log/fazai \
-  -e FAZAI_PORT=3210 \
+  -e FAZAI_PORT=3120 \
   fazai:latest
 ```
 
 #### Portas Oficiais do FazAI
 
 O FazAI utiliza a seguinte faixa de portas reservada:
-- **3210**: Porta padrão do FazAI
-- **3210-3215**: Range reservado para serviços do FazAI
+- **3120**: Porta padrão do FazAI
+- **3120-3125**: Range reservado para serviços do FazAI
 
 #### Volumes do Container
 
@@ -84,7 +84,7 @@ O FazAI utiliza a seguinte faixa de portas reservada:
 
 #### Variáveis de Ambiente
 
-- `FAZAI_PORT`: Porta de execução (padrão: 3210)
+- `FAZAI_PORT`: Porta de execução (padrão: 3120)
 - `NODE_ENV`: Ambiente de execução (padrão: production)
 
 ## Uso Básico

--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@
 (É cogitavel a utilizaçao de uma API que comunica com um ollama em um pequeno modelo na nuvem para rapido diagnostico ou inicialmente apenas registros por telemetria afim de iniciar uma base de bugtrack).
 
 3. Seria interessante para facilitar a configuraçao
-(/etc/fazai/fazai.conf), tanto na parte de ais, de plan, act, fallback, keys, etc.. uma interface TUI inicial, vindo evoluir futuramente para uma interface java. ALTERAR A PORTA DE COMUNICAÇAO DO DAEMON DO FAZAI CASO UTILIZE ALEM DO DOCKER PARA A NOVA PORTA OFICIAL 3210.
+(/etc/fazai/fazai.conf), tanto na parte de ais, de plan, act, fallback, keys, etc.. uma interface TUI inicial, vindo evoluir futuramente para uma interface java. MANTER A PORTA PADRÃO DO DAEMON DO FAZAI EM 3120.
 
 4. Conferir a estrutura de forma que os devidos arquivos fiquem nos devidos diretorios conforme conformidades e estrutura organizacional proposta.. ex.. /etc /opt/ /var etc... 
 
@@ -30,7 +30,7 @@ Confirmar que o script de instalação funcione corretamente em ambientes Linux 
 #12. Implementar um sistema de monitoramento e alerta para o fazai, que #notifique o usuário sobre falhas, problemas de desempenho ou qualquer #outra anomalia que possa ocorrer durante a operação do sistema. 
 
 13. Criar um Dockerfile e/ou uma imagem Docker pronta contendo todas as dependências do FazAI, permitindo a execução do sistema em qualquer ambiente via container. O container deve:
-    - Utilizar a nova porta oficial 3210 (range reservado: 3210-3215) para comunicação
+    - Utilizar a porta oficial 3120 (range reservado: 3120-3125) para comunicação
     - Conter uma versão funcional do FazAI já instalada e configurada
     - Incluir todas as dependências necessárias para execução
     - Permitir persistência de dados e configurações via volumes

--- a/bin/fazai
+++ b/bin/fazai
@@ -52,7 +52,7 @@ if (!fs.existsSync(mainJsPath)) {
 }
 
 // Configuração do cliente
-const API_URL = process.env.FAZAI_API_URL || 'http://localhost:3210';
+const API_URL = process.env.FAZAI_API_URL || 'http://localhost:3120';
 const LOG_FILE = '/var/log/fazai/fazai.log';
 
 // Cores para saída no terminal

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -22,8 +22,8 @@ fi
 
 # Verificar variáveis de ambiente
 if [ -z "$FAZAI_PORT" ]; then
-    log "FAZAI_PORT não definida. Usando porta padrão 3210"
-    export FAZAI_PORT=3210
+    log "FAZAI_PORT não definida. Usando porta padrão 3120"
+    export FAZAI_PORT=3120
 fi
 
 # Verificar permissões

--- a/etc/fazai/fazai.service
+++ b/etc/fazai/fazai.service
@@ -20,7 +20,7 @@ StandardError=append:/var/log/fazai/stderr.log
 
 # Definição de ambiente
 Environment=NODE_ENV=production
-Environment=FAZAI_PORT=3210
+Environment=FAZAI_PORT=3120
 EnvironmentFile=-/etc/fazai/env
 
 # Limites de sistema

--- a/install.sh
+++ b/install.sh
@@ -555,7 +555,7 @@ console.log('FazAI v1.3.7 - Iniciando...');
 
 // Configuração básica
 const config = {
-  port: process.env.FAZAI_PORT || 3210,
+  port: process.env.FAZAI_PORT || 3120,
   logLevel: process.env.FAZAI_LOG_LEVEL || 'info'
 };
 
@@ -785,7 +785,7 @@ echo "
         </div>
     </div>
     <script>
-        const API_URL = 'http://localhost:3210';
+        const API_URL = 'http://localhost:3120';
         
         async function viewLogs() {
             try {

--- a/opt/fazai/lib/main.js
+++ b/opt/fazai/lib/main.js
@@ -43,7 +43,7 @@ const logger = winston.createLogger({
 
 // Configuração do servidor Express
 const app = express();
-const PORT = process.env.PORT || 3210;
+const PORT = process.env.PORT || 3120;
 
 // Middleware para processar JSON
 app.use(express.json());

--- a/opt/fazai/tools/fazai-config.js
+++ b/opt/fazai/tools/fazai-config.js
@@ -118,7 +118,7 @@ function loadConfig() {
         system: {
           max_memory: '512M',
           threads: '4',
-          port: '3210',
+          port: '3120',
           host: 'localhost',
         }
       };

--- a/opt/fazai/tools/fazai-tui.sh
+++ b/opt/fazai/tools/fazai-tui.sh
@@ -6,7 +6,7 @@
 # Configurações
 CONFIG_FILE="/etc/fazai/fazai.conf"
 LOG_FILE="/var/log/fazai/fazai.log"
-API_URL="http://localhost:3210"
+API_URL="http://localhost:3120"
 DIALOG_TITLE="FazAI - Dashboard TUI"
 VERSION="1.3.7"
 
@@ -424,7 +424,7 @@ configure_api_keys() {
 
 # Função para configurar daemon
 configure_daemon() {
-    local port=$(grep '^daemon_port' "$CONFIG_FILE" 2>/dev/null | cut -d'=' -f2 | xargs || echo "3210")
+    local port=$(grep '^daemon_port' "$CONFIG_FILE" 2>/dev/null | cut -d'=' -f2 | xargs || echo "3120")
     local log_level=$(grep '^log_level' "$CONFIG_FILE" 2>/dev/null | cut -d'=' -f2 | xargs || echo "info")
     
     exec 3>&1

--- a/opt/fazai/tools/fazai_web_frontend.html
+++ b/opt/fazai/tools/fazai_web_frontend.html
@@ -361,7 +361,7 @@
                 <h3>🔧 Configuração</h3>
                 <div class="input-group">
                     <label for="apiUrl">URL da API:</label>
-                    <input type="text" id="apiUrl" value="http://localhost:3210">
+                    <input type="text" id="apiUrl" value="http://localhost:3120">
                 </div>
                 <div class="input-group">
                     <label for="refreshInterval">Intervalo de atualização (ms):</label>
@@ -376,7 +376,7 @@
     <script>
         // Configuração global
         let config = {
-            apiUrl: 'http://localhost:3210',
+            apiUrl: 'http://localhost:3120',
             refreshInterval: 5000
         };
 


### PR DESCRIPTION
## Summary
- restore correct default port 3120
- update reserved port range to 3120-3125
- correct docs and scripts using the old 3210 port

## Testing
- `npm test` *(fails: Version mismatch)*
- `bash tests/version.test.sh` *(fails: Version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68621c783264832ea286b587bdfa28ca