### PR TITLE
Update install to use Node.js 22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [22.x]
     
     steps:
     - uses: actions/checkout@v3
@@ -43,10 +43,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     
-    - name: Use Node.js 20.x
+    - name: Use Node.js 22.x
       uses: actions/setup-node@v3
       with:
-        node-version: 20.x
+        node-version: 22.x
         cache: 'npm'
     
     - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Documentação completa das movimentações em `MOVED_FILES_SUMMARY.md`
 
 ### Changed
-- Requisito mínimo atualizado para Node.js 18 e Python 3.10
+- Requisito mínimo atualizado para Node.js 22 e Python 3.10
 - **Reorganização de arquivos:** Movidos para locais apropriados:
   - `sync-changes.sh` → `bin/tools/sync-changes.sh`
   - `system_mod.so` → `opt/fazai/mods/system_mod.so`

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ FazAI é um sistema de automação inteligente para servidores Linux, que permit
 
 ## Requisitos
 
-- Node.js 18.x ou superior
-- npm 8.x ou superior
+- Node.js 22.x ou superior
+- npm 10.x ou superior
 - Python 3.10 ou superior
 - Sistema operacional: Debian/Ubuntu ou WSL com Debian/Ubuntu
 

--- a/bin/tools/system-check.sh
+++ b/bin/tools/system-check.sh
@@ -27,8 +27,8 @@ check_dependencies() {
     # Verifica versões mínimas de Node.js e Python
     local node_version=$(node -v 2>/dev/null | sed 's/v//')
     local node_major=$(echo "$node_version" | cut -d. -f1)
-    if [ -n "$node_major" ] && [ "$node_major" -lt 18 ]; then
-        log "ERRO: Node.js 18 ou superior é requerido (versão atual: $node_version)"
+    if [ -n "$node_major" ] && [ "$node_major" -lt 22 ]; then
+        log "ERRO: Node.js 22 ou superior é requerido (versão atual: $node_version)"
         return 1
     fi
 

--- a/install.sh
+++ b/install.sh
@@ -35,8 +35,8 @@ INSTALL_STATE_FILE="/var/lib/fazai/install.state"
 
 # Dependências do sistema e suas versões mínimas
 declare -A SYSTEM_DEPENDENCIES=(
-    ["node"]="18.0.0"
-    ["npm"]="8.0.0"
+    ["node"]="22.0.0"
+    ["npm"]="10.0.0"
     ["python3"]="3.10.0"
     ["pip3"]="21.0"
     ["gcc"]="7.0.0"
@@ -45,7 +45,7 @@ declare -A SYSTEM_DEPENDENCIES=(
 )
 
 # Repositórios alternativos para fallback
-NODE_VERSIONS=("22" "20" "18")
+NODE_VERSIONS=("22")
 REPOSITORIES=(
     "https://deb.nodesource.com/setup_"
     "https://nodejs.org/dist/v"
@@ -333,12 +333,12 @@ install_nodejs() {
     NODE_VERSION=$(node -v)
     log "SUCCESS" "Node.js já instalado: $NODE_VERSION"
     
-  # Verifica versão mínima do Node.js (>=18.0.0)
+  # Verifica versão mínima do Node.js (>=22.0.0)
     NODE_VERSION_NUM=$(echo $NODE_VERSION | cut -c 2-)
     NODE_MAJOR=$(echo $NODE_VERSION_NUM | cut -d. -f1)
     
-  if [ $NODE_MAJOR -lt 18 ]; then
-      log "WARNING" "FazAI requer Node.js versão 18.0.0 ou superior. Versão atual: $NODE_VERSION"
+  if [ $NODE_MAJOR -lt 22 ]; then
+      log "WARNING" "FazAI requer Node.js versão 22.0.0 ou superior. Versão atual: $NODE_VERSION"
       log "INFO" "Tentando atualizar o Node.js..."
       install_nodejs_from_source
     fi
@@ -365,7 +365,7 @@ install_nodejs_from_source() {
     NODE_VERSION_NUM=$(echo $NODE_VERSION | cut -c 2-)
     NODE_MAJOR=$(echo $NODE_VERSION_NUM | cut -d. -f1)
     
-    if [ $NODE_MAJOR -ge 18 ]; then
+    if [ $NODE_MAJOR -ge 22 ]; then
       log "SUCCESS" "Node.js instalado com sucesso via apt: $NODE_VERSION"
       success=true
       return 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "nodemon": ">=2.0.19"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@colors/colors": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "nodemon": ">=2.0.19"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- default Node requirement updated to 22
- update docs and changelog
- update CI matrix and system check script

## Testing
- `npm test` *(fails: Version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68621ec44178832e90a082e4659aee65