### PR TITLE
Bump FazAI version to 1.40

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,7 @@ cole aqui os logs (use o comando 'fazai logs 20' para obter os últimos 20 logs)
 **Ambiente (por favor, complete as seguintes informações):**
  - Sistema Operacional: [ex. Ubuntu 22.04]
  - Versão do Node.js: [ex. 20.10.0]
- - Versão do FazAI: [ex. 1.3.1]
+ - Versão do FazAI: [ex. 1.40]
 
 **Informações adicionais**
 Adicione qualquer outra informação sobre o problema aqui.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v1.40] - 30/06/2025
+
+### Changed
+- Atualização de versionamento para **1.40**.
+
 ## [v1.3.8] - 14/06/2025
 
 ### Changed

--- a/bin/fazai
+++ b/bin/fazai
@@ -339,7 +339,7 @@ ${colors.bright}Exemplos:${colors.reset}
   }
   
   if (args[0] === 'versao' || args[0] === 'version' || args[0] === '--version' || args[0] === '-v') {
-    console.log(`FazAI v1.3.1`);
+    console.log(`FazAI v1.40`);
     process.exit(0);
   }
   

--- a/complete_update.sh
+++ b/complete_update.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Script para completar as atualizações do FazAI v1.3.7
+# Script para completar as atualizações do FazAI v1.40
 
-echo "🔧 Completando atualizações do FazAI v1.3.7..."
+echo "🔧 Completando atualizações do FazAI v1.40..."
 
 # Backup dos arquivos originais
 cp install.sh install.sh.backup
@@ -36,7 +36,7 @@ grep "fazai-html" uninstall.sh && echo "✅ fazai-html encontrado no uninstall.s
 
 echo ""
 echo "🎯 Resumo das atualizações:"
-echo "✅ Versões corrigidas para 1.3.7"
+echo "✅ Versões corrigidas para 1.40"
 echo "✅ fazai_web.sh incorporado"
 echo "🔧 fazai_html_v1.sh preparado (necessita edição manual do install.sh)"
 echo "✅ uninstall.sh atualizado"

--- a/install.sh
+++ b/install.sh
@@ -28,7 +28,7 @@ CYAN='\033[0;36m'
 NC='\033[0m' # No Color
 
 # Variáveis de configuração
-VERSION="1.3.7"
+VERSION="1.40"
 LOG_FILE="/var/log/fazai_install.log"
 RETRY_COUNT=3
 INSTALL_STATE_FILE="/var/lib/fazai/install.state"
@@ -551,7 +551,7 @@ copy_files() {
 const fs = require('fs');
 const path = require('path');
 
-console.log('FazAI v1.3.7 - Iniciando...');
+console.log('FazAI v1.40 - Iniciando...');
 
 // Configuração básica
 const config = {
@@ -593,7 +593,7 @@ const fs = require('fs');
 const args = process.argv.slice(2);
 
 if (args.includes('--version')) {
-  console.log('FazAI v1.3.7');
+  console.log('FazAI v1.40');
   process.exit(0);
 }
 
@@ -623,7 +623,7 @@ if (args.includes('--status')) {
   process.exit(0);
 }
 
-console.log('FazAI CLI v1.3.7 - Use --help para mais informações');
+console.log('FazAI CLI v1.40 - Use --help para mais informações');
 EOF
     chmod +x "bin/fazai"
   fi
@@ -727,7 +727,7 @@ EOF
     cat > "/opt/fazai/tools/fazai-tui.sh" << 'EOF'
 #!/bin/bash
 # FazAI Dashboard TUI - Versão Básica
-echo "FazAI Dashboard TUI v1.3.7"
+echo "FazAI Dashboard TUI v1.40"
 echo "
   if [ -f "opt/fazai/tools/fazai_web_frontend.html" ]; then
     copy_with_verification "opt/fazai/tools/fazai_web_frontend.html" "/opt/fazai/tools/" "Interface web"
@@ -999,7 +999,7 @@ install_node_dependencies() {
     cat > "package.json" << 'EOF'
 {
   "name": "fazai",
-  "version": "1.3.7",
+  "version": "1.40",
   "description": "FazAI - Orquestrador Inteligente de Automação",
   "main": "main.js",
   "dependencies": {
@@ -1100,7 +1100,7 @@ install_tui() {
 const fs = require('fs');
 const path = require('path');
 
-console.log('FazAI - Interface de Configuração TUI v1.3.7');
+console.log('FazAI - Interface de Configuração TUI v1.40');
 console.log('=========================================');
 console.log('');
 console.log('Funcionalidades disponíveis:');

--- a/opt/fazai/lib/main.js
+++ b/opt/fazai/lib/main.js
@@ -490,7 +490,7 @@ app.get('/status', (req, res) => {
     success: true, 
     status: 'online',
     timestamp: new Date().toISOString(),
-    version: '1.3.1'
+    version: '1.40'
   });
 });
 

--- a/opt/fazai/tools/fazai-tui.sh
+++ b/opt/fazai/tools/fazai-tui.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 # FazAI - Interface TUI Dashboard Completa
 # Caminho: /opt/fazai/tools/fazai-tui.sh
-# Versão: 1.3.7
+# Versão: 1.40
 
 # Configurações
 CONFIG_FILE="/etc/fazai/fazai.conf"
 LOG_FILE="/var/log/fazai/fazai.log"
 API_URL="http://localhost:3120"
 DIALOG_TITLE="FazAI - Dashboard TUI"
-VERSION="1.3.7"
+VERSION="1.40"
 
 # Cores para dialog
 export DIALOGRC="/tmp/fazai_dialogrc"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fazai",
-  "version": "1.3.7",
+  "version": "1.40",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fazai",
-      "version": "1.3.7",
+      "version": "1.40",
       "dependencies": {
         "axios": ">=0.27.2",
         "blessed": ">=0.1.81",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fazai",
-  "version": "1.3.7",
+  "version": "1.40",
   "description": "FazAI - Orquestrador Inteligente de Automação",
   "main": "opt/fazai/lib/main.js",
   "scripts": {

--- a/tests/version.test.sh
+++ b/tests/version.test.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
-EXPECTED="$(node -p "require('./package.json').version")"
+EXPECTED="1.40"
+PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+if [ "$PACKAGE_VERSION" != "$EXPECTED" ]; then
+  echo "package.json version mismatch: expected $EXPECTED but found $PACKAGE_VERSION"
+  exit 1
+fi
 OUTPUT="$(node ./bin/fazai --version 2>/dev/null | tr -d '\r\n')"
 if [ "$OUTPUT" = "FazAI v$EXPECTED" ]; then
   echo "Version test passed: $OUTPUT"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -2,7 +2,7 @@
 
 # FazAI - Script de Desinstalação
 # Este script remove o FazAI do sistema
-# Versão: 1.3.7 - Atualizado para lidar com arquivos movidos e conversão dos2unix
+# Versão: 1.40 - Atualizado para lidar com arquivos movidos e conversão dos2unix
 
 # Cores para saída no terminal
 RED='\033[0;31m'
@@ -13,7 +13,7 @@ PURPLE='\033[0;35m'
 NC='\033[0m' # No Color
 
 # Versão do script
-VERSION="1.3.7"
+VERSION="1.40"
 
 # Função para exibir mensagens
 print_message() {
@@ -90,7 +90,7 @@ if [ "$PRESERVE_CONFIG" = true ]; then
         print_success "Configuração principal salva no backup"
     fi
     
-    # Backup das ferramentas específicas (arquivos movidos na v1.3.7)
+    # Backup das ferramentas específicas (arquivos movidos na v1.40)
     TOOLS_TO_BACKUP=(
         "/opt/fazai/tools/github-setup.sh"
         "/opt/fazai/tools/sync-changes.sh"
@@ -150,7 +150,7 @@ for link in fazai-config fazai-backup fazai-uninstall fazai-config-tui fazai-tui
     fi
 done
 
-# Remove ferramentas específicas movidas para /opt/fazai/tools/ (v1.3.7)
+# Remove ferramentas específicas movidas para /opt/fazai/tools/ (v1.40)
 print_message "Removendo ferramentas específicas..."
 TOOLS_TO_REMOVE=(
     "/opt/fazai/tools/github-setup.sh"
@@ -184,7 +184,7 @@ for module in "${NATIVE_MODULES[@]}"; do
     fi
 done
 
-# Remove arquivos relacionados ao dos2unix e conversão de formato (v1.3.7)
+# Remove arquivos relacionados ao dos2unix e conversão de formato (v1.40)
 print_message "Removendo arquivos de conversão de formato..."
 DOS2UNIX_FILES=(
     "/etc/fazai/dos2unixAll.sh"
@@ -266,7 +266,7 @@ if [ -f /etc/sudoers.d/fazai ]; then
     print_success "Configuração sudoers removida."
 fi
 
-# Remove arquivos de estado de instalação se existirem (v1.3.7)
+# Remove arquivos de estado de instalação se existirem (v1.40)
 if [ -f /var/lib/fazai/install.state ]; then
     rm -f /var/lib/fazai/install.state
     print_success "Estado de instalação removido."
@@ -290,7 +290,7 @@ if [ "$PRESERVE_CONFIG" = true ]; then
     echo -e "Backup adicional disponível em: ${BLUE}$BACKUP_DIR${NC}"
 fi
 
-echo -e "${PURPLE}[INFO]${NC} Limpeza específica da versão 1.3.7 concluída:"
+echo -e "${PURPLE}[INFO]${NC} Limpeza específica da versão 1.40 concluída:"
 echo -e "  • Ferramentas movidas removidas"
 echo -e "  • Módulos nativos removidos"
 echo -e "  • Arquivos dos2unix removidos"


### PR DESCRIPTION
## Summary
- update version references to 1.40
- ensure test checks for new version
- record 1.40 release in changelog

## Testing
- `bash tests/version.test.sh` *(fails: Version mismatch)*
- `npm test` *(fails: Version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6862ae583d44832e894928a6c4a9c715