### PR TITLE
Add optional llama.cpp install

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ cd FazAI
 
 # Instalar
 sudo ./install.sh
+# Opcional: incluir suporte ao llama.cpp
+# sudo ./install.sh --with-llama
 
 # Iniciar o serviço
 sudo systemctl enable fazai

--- a/bin/tools/install-llamacpp.sh
+++ b/bin/tools/install-llamacpp.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/bash
+set -e
+
+LLAMA_DIR="/opt/fazai/llama.cpp"
+MODEL_DIR="$LLAMA_DIR/models"
+MODEL_URL="https://huggingface.co/datasets/ggerganov/llama.cpp/resolve/main/stories15M.bin"
+MODEL_FILE="stories15M.bin"
+
+echo "=== FazAI - Instalando llama.cpp ==="
+
+if [ ! -d "$LLAMA_DIR" ]; then
+    git clone --depth 1 https://github.com/ggerganov/llama.cpp "$LLAMA_DIR"
+else
+    echo "Atualizando repositório llama.cpp..."
+    git -C "$LLAMA_DIR" pull
+fi
+
+cd "$LLAMA_DIR"
+make
+
+mkdir -p "$MODEL_DIR"
+if [ ! -f "$MODEL_DIR/$MODEL_FILE" ]; then
+    echo "Baixando modelo de exemplo ($MODEL_FILE)..."
+    curl -L -o "$MODEL_DIR/$MODEL_FILE" "$MODEL_URL" || echo "Falha ao baixar modelo"
+fi
+
+echo "llama.cpp instalado em $LLAMA_DIR"


### PR DESCRIPTION
## Summary
- create script to build llama.cpp with a tiny model
- add `--with-llama` option to installer
- document optional llama.cpp installation in README

## Testing
- `npm test` *(fails: Version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6862b57157f8832e92233269555e2bff