### PR TITLE
Install Node.js 22 in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,14 @@ FROM debian:stable-slim
 ENV FAZAI_PORT=3120 \
     NODE_ENV=production
 
-# Instalar dependências do sistema
+# Instalar dependências do sistema e Node.js 22 a partir da NodeSource
 RUN apt-get update && apt-get install -y \
     curl \
+    gnupg \
     git \
-    nodejs \
-    npm \
     systemd \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 # Criar diretórios necessários
@@ -19,7 +20,9 @@ RUN mkdir -p /opt/fazai /etc/fazai /var/log/fazai
 
 # Copiar arquivos do FazAI
 COPY bin/ /opt/fazai/bin/
-COPY etc/ /etc/fazai/
+COPY etc/fazai/ /etc/fazai/
+RUN rm -f /etc/fazai/fazai.conf
+COPY etc/fazai/fazai.conf.example /etc/fazai/
 COPY package.json /opt/fazai/
 COPY install.sh /opt/fazai/
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -31,6 +31,9 @@ log "Verificando permissões..."
 chown -R root:root /opt/fazai
 chmod -R 755 /opt/fazai/bin
 
+# Informar versão do Node.js
+log "Usando Node.js $(node -v)"
+
 # Iniciar o FazAI
 log "Iniciando FazAI na porta $FAZAI_PORT"
 exec "$@"


### PR DESCRIPTION
## Summary
- use NodeSource setup script to install Node.js 22
- copy correct config example and remove default config
- log Node.js version during container startup

## Testing
- `npm test` *(fails: Version mismatch: expected 'FazAI v1.40' but got '')*
- `npm install` *(fails to download packages: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6862b6b84e70832e94b5426fd8c68a2f