### PR TITLE
Add optional Rust TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ fazai altere a porta do ssh de 22 para 31052
 /usr/local/bin/fazai  # Link simbólico para o CLI
 ```
 
+## Interface TUI
+
+Se o `cargo` estiver disponível durante a instalação, o FazAI compila um painel
+TUI em Rust usando a biblioteca `ratatui`. O binário resultante é instalado em
+`/usr/local/bin/fazai-tui`. Caso o Rust não esteja presente ou a compilação
+falhe, o instalador mantém o painel Bash tradicional localizado em
+`/opt/fazai/tools/fazai-tui.sh`.
+
 ## Configuração
 
 O arquivo principal de configuração está em `/etc/fazai/fazai.conf`. Para criar:

--- a/install.sh
+++ b/install.sh
@@ -723,6 +723,16 @@ EOF
     chmod +x /opt/fazai/tools/fazai-tui.sh
     ln -sf /opt/fazai/tools/fazai-tui.sh /usr/local/bin/fazai-tui
     log "SUCCESS" "Dashboard TUI completo instalado em /usr/local/bin/fazai-tui"
+    if command -v cargo >/dev/null 2>&1; then
+      log "INFO" "Compilando TUI em Rust..."
+      if cargo build --release --manifest-path=tui/Cargo.toml >/tmp/fazai_tui_build.log 2>&1; then
+        cp tui/target/release/fazai-tui /opt/fazai/tools/fazai-tui-rs
+        ln -sf /opt/fazai/tools/fazai-tui-rs /usr/local/bin/fazai-tui
+        log "SUCCESS" "TUI Rust instalado em /usr/local/bin/fazai-tui"
+      else
+        log "WARNING" "Falha ao compilar TUI Rust, utilizando script bash"
+      fi
+    fi
   else
     log "WARNING" "Dashboard TUI não encontrado, criando versão básica..."
     cat > "/opt/fazai/tools/fazai-tui.sh" << 'EOF'

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "fazai-tui"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+ratatui = "0.24"
+crossterm = "0.27"

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -1,0 +1,33 @@
+use std::io::{self};
+use crossterm::{event, terminal, ExecutableCommand};
+use ratatui::{prelude::*, widgets::*};
+
+fn main() -> Result<(), io::Error> {
+    let mut stdout = io::stdout();
+    terminal::enable_raw_mode()?;
+    stdout.execute(terminal::EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    loop {
+        terminal.draw(|f| {
+            let size = f.size();
+            let block = Block::default()
+                .title("FazAI Dashboard")
+                .borders(Borders::ALL);
+            f.render_widget(block, size);
+        })?;
+
+        if event::poll(std::time::Duration::from_millis(50))? {
+            if let event::Event::Key(key) = event::read()? {
+                if key.code == event::KeyCode::Char('q') {
+                    break;
+                }
+            }
+        }
+    }
+
+    terminal::disable_raw_mode()?;
+    terminal.show_cursor()?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add `tui` crate using `ratatui` and simple dashboard example
- compile the Rust TUI during `install.sh` when cargo is present
- document TUI fallback behaviour in the README

## Testing
- `npm test`
- `cargo build --manifest-path tui/Cargo.toml` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6862da5fbf08832e85e927aba5e7cab7