### PR TITLE
Ensure install.sh handles arbitrary calling dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ cd FazAI
 
 # Instalar
 sudo ./install.sh
+# O script identifica automaticamente seu diretório,
+# permitindo executá-lo de qualquer caminho (por exemplo
+# `sudo /caminho/para/install.sh`).
 # Opcional: incluir suporte ao llama.cpp
 # sudo ./install.sh --with-llama
 
@@ -56,6 +59,8 @@ wget https://github.com/RLuf/FazAI/releases/latest/download/fazai-portable.tar.g
 tar -xzf fazai-portable.tar.gz
 cd fazai-portable-*
 sudo ./install.sh
+# Assim como na instalação principal, o script pode ser
+# chamado de qualquer pasta, pois detecta seu próprio caminho.
 ```
 
 ### Instalação via Docker

--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,10 @@ if [ "$EUID" -ne 0 ]; then
     exit 1
 fi
 
+# Garante que o script opere em seu diretório independente de onde for chamado
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
 # Cores para saída no terminal
 RED='\033[0;31m'
 GREEN='\033[0;32m'


### PR DESCRIPTION
## Summary
- use script directory for all relative paths in install.sh
- explain portability of install.sh in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68634a2e9f3c832e98dc81231393558a