### PR TITLE
Improve node dependency checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,11 @@ Recomendações básicas:
 - Configurar firewall
 - Auditar logs regularmente
 
+## Solução de Problemas
+
+Se encontrar erros durante a instalação, consulte o arquivo de log
+`/var/log/fazai_install.log` para obter detalhes e mensagens do script.
+
 ## Autor
 
 Roger Luft, Fundador do FazAI

--- a/install.sh
+++ b/install.sh
@@ -1111,6 +1111,14 @@ EOF
   fi
   
   cd - > /dev/null
+
+  # Verifica se os módulos essenciais foram instalados
+  if npm list express winston >/dev/null 2>&1; then
+    log "SUCCESS" "Módulos express e winston instalados corretamente."
+  else
+    log "WARNING" "Falha ao verificar express e winston. Verifique a conexão de rede e execute 'npm install' manualmente."
+  fi
+
   log "SUCCESS" "Dependências do Node.js instaladas."
 }
 


### PR DESCRIPTION
## Summary
- verify critical node modules inside `install_node_dependencies`
- document install log location

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68634d767998832e9b5352700cc4abba