### PR TITLE
Ensure install.sh runs from any path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 - Atualização de versionamento para **1.40**.
+- `install.sh` detecta seu diretório e ajusta o `cd`,
+  garantindo funcionamento quando chamado de qualquer local.
 
 ## [v1.3.8] - 14/06/2025
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ cd FazAI
 
 # Instalar
 sudo ./install.sh
-# O script identifica automaticamente seu diretório,
-# permitindo executá-lo de qualquer caminho (por exemplo
-# `sudo /caminho/para/install.sh`).
+# O instalador detecta seu próprio caminho, permitindo
+# executá-lo de qualquer diretório. Exemplo:
+# sudo /caminho/para/install.sh
 # Opcional: incluir suporte ao llama.cpp
 # sudo ./install.sh --with-llama
 


### PR DESCRIPTION
## Summary
- clarify in README that install.sh can run from any location
- document install.sh path handling in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68639bdbba0c832e9437e0834cc44abd