### PR TITLE
Improve copy failure handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v1.40.1] - 01/07/2025
+
+### Fixed
+- Instalador interrompe ao detectar erro em `copy_files`, informando para verificar o log.
+- Mensagens de erro detalham qual arquivo falhou na cópia e o motivo.
+
+## [v1.40.2] - 01/07/2025
+
+### Fixed
+- Removido caminho incorreto `/etc/fazai/main.js` em scripts e instalador.
+- `build-portable.sh` e `bin/fazai` agora usam `/opt/fazai/lib/main.js` como padrão.
+
 ## [v1.40] - 30/06/2025
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 - Removido caminho incorreto `/etc/fazai/main.js` em scripts e instalador.
 - `build-portable.sh` e `bin/fazai` agora usam `/opt/fazai/lib/main.js` como padrão.
 
+## [v1.40.3] - 01/07/2025
+
+### Fixed
+- Ajustadas referências incorretas a `/etc/fazai/tools/` e `/etc/fazai/mods/`.
+- `build-portable.sh` e documentação agora apontam para `/opt/fazai` para plugins e módulos.
+
 ## [v1.40] - 30/06/2025
 
 ### Changed

--- a/CONTENT.txt
+++ b/CONTENT.txt
@@ -19,7 +19,7 @@ Diretrizes:
 
 OBS: utilizar um  framework robusto se possivel ja atuando em userspace, daemon e kernel.
 
-A estrutura inicial consiste em /etc/fazai/main.py daemon principal carregado por um systemd (sugestao)
+A estrutura inicial consiste em /opt/fazai/lib/main.js, daemon principal carregado por um systemd (sugestão)
                                           |-tools
                                           |-fazai (onde eh linkado com /bin/fazai) ou um alias no .bashrc
                                           |/etc/systemd/system/fazai.service
@@ -104,7 +104,7 @@ O sistema será composto por dois principais componentes:
 ### 3. Estrutura de Diretórios
 
 ```
-/etc/fazai/
+/opt/fazai/
     main.js           # Daemon principal (Node.js)
     /tools/           # Plugins e scripts auxiliares (Node.js)
     /mods/            # Módulos nativos (C, .so)
@@ -121,7 +121,7 @@ O sistema será composto por dois principais componentes:
 
 - Use framework robusto (ex: Express para REST, ou net para sockets UNIX).
 - Modularize comandos e handlers.
-- Carregue plugins dinamicamente de `/etc/fazai/tools/`.
+- Carregue plugins dinamicamente de `/opt/fazai/tools/`.
 - Carregue módulos nativos via `ffi-napi-v22` ou `node-ffi` para integração com C.
 - Implemente fallback para múltiplos modelos de IA.
 - Gerencie cache e reinicialização automática dos serviços.
@@ -161,7 +161,7 @@ void fazai_mod_cleanup();
 
 ### 6. Expansão e Plugins
 
-- Plugins em `/etc/fazai/tools/` podem ser scripts Node.js ou wrappers para binários externos.
+- Plugins em `/opt/fazai/tools/` podem ser scripts Node.js ou wrappers para binários externos.
 - Plugins devem seguir interface padrão para fácil integração.
 
 ---
@@ -225,7 +225,7 @@ Estrutura de Diretórios
 bash
 
 
-/etc/fazai/
+/opt/fazai/
     main.js           # Daemon principal (Node.js)
     /tools/           # Plugins e scripts auxiliares (Node.js)
     /mods/            # Módulos nativos (C, .so)
@@ -236,7 +236,7 @@ Detalhes Técnicos
 Daemon (Node.js)
 Utilize um framework robusto como o Express para REST ou net para sockets UNIX.
 Modularize comandos e handlers.
-Carregue plugins dinamicamente de /etc/fazai/tools/.
+Carregue plugins dinamicamente de /opt/fazai/tools/.
 Carregue módulos nativos via ffi-napi-v22 ou node-ffi para integração com C.
 Implemente fallback para múltiplos modelos de IA.
 Gerencie cache e reinicialização automática dos serviços.
@@ -270,7 +270,7 @@ Inicialmente, ignore mecanismos de segurança avançados, mas mantenha logs deta
 Todos os comandos e respostas devem ser logados.
 Estruture logs para fácil auditoria e futura integração com SIEM.
 Expansão e Plugins
-Plugins em /etc/fazai/tools/ podem ser scripts Node.js ou wrappers para binários externos.
+Plugins em /opt/fazai/tools/ podem ser scripts Node.js ou wrappers para binários externos.
 Plugins devem seguir uma interface padrão para fácil integração.
 Exemplos de Comando
 fazai cria usuario nome=teste senha=teste321 grupo=printers
@@ -332,7 +332,7 @@ Estrutura de Diretórios
 bash
 
 
-/etc/fazai/
+/opt/fazai/
     main.js           # Daemon principal (Node.js)
     /tools/           # Plugins e scripts auxiliares (Node.js)
     /mods/            # Módulos nativos (C, .so)
@@ -343,7 +343,7 @@ Detalhes Técnicos
 Daemon (Node.js)
 Utilize um framework robusto como o Express para REST ou net para sockets UNIX.
 Modularize comandos e handlers.
-Carregue plugins dinamicamente de /etc/fazai/tools/.
+Carregue plugins dinamicamente de /opt/fazai/tools/.
 Carregue módulos nativos via ffi-napi-v22 ou node-ffi para integração com C.
 Implemente fallback para múltiplos modelos de IA.
 Gerencie cache e reinicialização automática dos serviços.
@@ -372,7 +372,7 @@ Inicialmente, ignore mecanismos de segurança avançados, mas mantenha logs deta
 Todos os comandos e respostas devem ser logados.
 Estruture logs para fácil auditoria e futura integração com SIEM.
 Expansão e Plugins
-Plugins em /etc/fazai/tools/ podem ser scripts Node.js ou wrappers para binários externos.
+Plugins em /opt/fazai/tools/ podem ser scripts Node.js ou wrappers para binários externos.
 Plugins devem seguir uma interface padrão para fácil integração.
 Exemplos de Comando
 fazai cria usuario nome=teste senha=teste321 grupo=printers

--- a/README.md
+++ b/README.md
@@ -155,13 +155,13 @@ sudo nano /etc/fazai/fazai.conf
 
 ### Plugins
 
-Crie plugins JavaScript em `/etc/fazai/tools/` implementando:
+Crie plugins JavaScript em `/opt/fazai/tools/` implementando:
 - Função `processCommand(command)`
 - Informações do plugin (nome, descrição, versão, autor)
 
 ### Módulos Nativos
 
-Crie módulos C em `/etc/fazai/mods/` implementando as funções definidas em `fazai_mod.h`.
+Crie módulos C em `/opt/fazai/mods/` implementando as funções definidas em `fazai_mod.h`.
 
 ## Testes
 

--- a/bin/fazai
+++ b/bin/fazai
@@ -512,9 +512,6 @@ ${colors.bright}Exemplos:${colors.reset}
     try {
       if (fs.existsSync('/opt/fazai/lib/main.js')) {
         printSuccess('Arquivo principal: Encontrado em /opt/fazai/lib/main.js');
-      } else if (fs.existsSync('/etc/fazai/main.js')) {
-        printWarning('Arquivo principal: Encontrado em /etc/fazai/main.js (localização antiga)');
-        printInfo('Sugestão: O arquivo principal foi movido para /opt/fazai/lib/main.js');
       } else {
         printError('Arquivo principal: Não encontrado');
       }

--- a/build-portable.sh
+++ b/build-portable.sh
@@ -96,11 +96,11 @@ cp -r bin/* $DIST_DIR/bin/
 chmod +x $DIST_DIR/bin/fazai
 
 # Copia bibliotecas principais
-if [ -f "etc/fazai/main.js" ]; then
+if [ -f "opt/fazai/lib/main.js" ]; then
     mkdir -p $DIST_DIR/lib
-    cp etc/fazai/main.js $DIST_DIR/lib/
+    cp opt/fazai/lib/main.js $DIST_DIR/lib/
 else
-    print_error "Arquivo main.js não encontrado em etc/fazai/"
+    print_error "Arquivo main.js não encontrado em opt/fazai/lib/"
     exit 1
 fi
 

--- a/build-portable.sh
+++ b/build-portable.sh
@@ -105,19 +105,19 @@ else
 fi
 
 # Copia ferramentas e plugins
-if [ -d "etc/fazai/tools" ]; then
-    cp -r etc/fazai/tools/* $DIST_DIR/tools/
+if [ -d "opt/fazai/tools" ]; then
+    cp -r opt/fazai/tools/* $DIST_DIR/tools/
 else
     print_warning "Diretório de ferramentas não encontrado."
     mkdir -p $DIST_DIR/tools
 fi
 
 # Copia módulos nativos
-if [ -d "etc/fazai/mods" ]; then
+if [ -d "opt/fazai/mods" ]; then
     # Compila módulos nativos se necessário
-    if [ -f "etc/fazai/mods/system_mod.c" ]; then
+    if [ -f "opt/fazai/mods/system_mod.c" ]; then
         print_message "Compilando módulos nativos para a arquitetura atual..."
-        cd etc/fazai/mods
+        cd opt/fazai/mods
         gcc -shared -fPIC -o system_mod.so system_mod.c
         if [ $? -ne 0 ]; then
             cd - > /dev/null
@@ -129,9 +129,9 @@ if [ -d "etc/fazai/mods" ]; then
     fi
     
     # Copia módulos nativos para o diretório específico da arquitetura
-    cp etc/fazai/mods/*.so $DIST_DIR/mods/$ARCH_DIR/
-    cp etc/fazai/mods/*.h $DIST_DIR/mods/
-    cp etc/fazai/mods/*.c $DIST_DIR/mods/
+    cp opt/fazai/mods/*.so $DIST_DIR/mods/$ARCH_DIR/
+    cp opt/fazai/mods/*.h $DIST_DIR/mods/
+    cp opt/fazai/mods/*.c $DIST_DIR/mods/
 else
     print_warning "Diretório de módulos nativos não encontrado."
     mkdir -p $DIST_DIR/mods/$ARCH_DIR


### PR DESCRIPTION
## Summary
- ensure `copy_with_verification` returns failure when a copy doesn't succeed
- stop installation when copying fails and tell the user to check the log
- clarify changelog
- fix wrong references to `/etc/fazai/main.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68639d005ba4832e8efdd90a342f1815