### PR TITLE
Configurar build do worker C++ com CMake

### DIFF
--- a/worker/CMakeLists.txt
+++ b/worker/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.16)
+project(fazai-gemma-worker LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# Ajuste o caminho da libgemma se necessário
+set(GEMMA_LIB_PATH "${CMAKE_SOURCE_DIR}/root/gemma.cpp/build/libgemma.a")
+
+add_executable(fazai-gemma-worker
+    src/main.cpp
+    src/worker.cpp
+    src/ipc.cpp
+)
+
+target_include_directories(fazai-gemma-worker PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}
+)
+
+target_link_libraries(fazai-gemma-worker
+    ${GEMMA_LIB_PATH}
+    pthread
+)


### PR DESCRIPTION
## Descrição

Criação do arquivo `worker/CMakeLists.txt` para configurar a compilação do executável C++ `fazai-gemma-worker`. Este worker é a engine C++ local do FazAI, projetada para se comunicar via socket Unix com o provider Node.js.

O arquivo define os requisitos de build, incluindo:
*   CMake mínimo 3.16 e linguagem C++17.
*   Ativação de `POSITION_INDEPENDENT_CODE ON`.
*   Inclusão dos diretórios `src` no include path.
*   Compilação dos arquivos `src/main.cpp`, `src/worker.cpp` e `src/ipc.cpp`.
*   Linkagem com a biblioteca estática `libgemma.a` (caminho configurável via `GEMMA_LIB_PATH`) e `pthread`.

Fixes # (issue)

## Tipo de alteração

Por favor, exclua as opções que não são relevantes.

- [ ] Correção de bug (alteração que corrige um problema)
- [x] Novo recurso (alteração que adiciona funcionalidade)
- [ ] Alteração significativa (correção ou recurso que faria com que a funcionalidade existente não funcionasse como esperado)
- [ ] Esta alteração requer uma atualização de documentação

## Como isso foi testado?

A alteração consistiu na criação de um novo arquivo `worker/CMakeLists.txt` com o conteúdo exato fornecido na especificação da tarefa. A verificação foi feita garantindo que o arquivo foi criado no local correto (`/worker/CMakeLists.txt`) e com o conteúdo idêntico ao solicitado. Não foram executados testes de compilação ou runtime nesta etapa, pois o escopo da tarefa era apenas a criação do arquivo de configuração.

- [x] Verificação da criação do arquivo e seu conteúdo exato.

## Checklist:

- [x] Meu código segue as diretrizes de estilo deste projeto (Conteúdo exato fornecido)
- [x] Realizei uma auto-revisão do meu próprio código (Verificado o conteúdo e localização)
- [x] Comentei meu código, particularmente em áreas difíceis de entender (Comentário existente no CMake sobre GEMMA_LIB_PATH)
- [ ] Fiz as alterações correspondentes na documentação (Não aplicável)
- [x] Minhas alterações não geram novos avisos (Criação de arquivo, não código executável)
- [ ] Adicionei testes que provam que minha correção é eficaz ou que meu recurso funciona (Não aplicável, apenas configuração de build)
- [ ] Testes unitários novos e existentes passam localmente com minhas alterações (Não aplicável)
- [ ] Quaisquer alterações dependentes foram mescladas e publicadas em módulos downstream (Não aplicável)

---
<a href="https://cursor.com/background-agent?bcId=bc-68d8faf2-2f7b-4be1-b5e6-f1dc12c1a32f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-68d8faf2-2f7b-4be1-b5e6-f1dc12c1a32f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

